### PR TITLE
Updates CODEOWNERS for datarouter and mw/log directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,13 @@
 # default owners
-* @antonkri @rmaddikery @hoppe-and-dreams @mobileinfo @andreapefe @RSingh1511 @Y-Vaishnavi @pawelrutkaq @arkjedrz @arsibo
+* @antonkri @pawelrutkaq @arkjedrz @arsibo
+
+# datarouter owners
+/score/datarouter @rmaddikery @hoppe-and-dreams @mobileinfo @andreapefe @RSingh1511 @Y-Vaishnavi
+
+# mw/log owners
+/score/mw/common_features.bzl @rmaddikery @hoppe-and-dreams @mobileinfo @andreapefe @RSingh1511 @Y-Vaishnavi
+
+/score/mw/log @rmaddikery @hoppe-and-dreams @mobileinfo @andreapefe @RSingh1511 @Y-Vaishnavi
+
+# mw/log rust mw_logger owners (more specific rule overrides general rule above)
+/score/mw/log/rust/mw_logger @pawelrutkaq @arkjedrz


### PR DESCRIPTION
- Assign codeowners to directories based on initial contributions

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
