### PR TITLE
Bumps score baselibs and communication deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -107,17 +107,17 @@ use_repo(toolchains_qnx, "toolchains_qnx_ifs")
 
 bazel_dep(name = "googletest", version = "1.17.0.bcr.1")
 bazel_dep(name = "rapidjson", version = "1.1.0")
-bazel_dep(name = "score_communication", version = "0.1.2")
+bazel_dep(name = "score_communication", version = "0.1.2", dev_dependency = True)
 git_override(
     module_name = "score_communication",
-    commit = "5a70133dd8bd632f5c07f200a5ee4bc9f507c23b",
+    commit = "73caa2d2b6f45f806bbd30bdf8675ab1ad551387",
     remote = "https://github.com/eclipse-score/communication.git",
 )
 
-bazel_dep(name = "score_baselibs", version = "0.2.0")
+bazel_dep(name = "score_baselibs", version = "0.2.0", dev_dependency = True)
 git_override(
     module_name = "score_baselibs",
-    commit = "3c65b223e9f516f95935bb4cd2e83d6088ca016f",
+    commit = "b60d09c7993c71e6b858304210ffb7d08133437a",
     remote = "https://github.com/eclipse-score/baselibs.git",
 )
 


### PR DESCRIPTION
- Addtionally marks them as dev_dependency so that these deps do not propogate to users of this module

- Required to fix integration of logging module in score-persistency:
https://github.com/eclipse-score/persistency/pull/228

- And, integration into reference platform:
https://github.com/eclipse-score/reference_integration/pull/79



<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
