### PR TITLE
docs: update templates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,9 +20,9 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "Module Template Project"
-project_url = "https://eclipse-score.github.io/module_template/"
-project_prefix = "MODULE_TEMPLATE_"
+project = "Logging"
+project_url = "https://eclipse-score.github.io/logging/"
+project_prefix = "LOG_"
 author = "S-CORE"
 version = "0.1"
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,10 +12,10 @@
    # SPDX-License-Identifier: Apache-2.0
    # *******************************************************************************
 
-Module Template Documentation
-=============================
+Logging Documentation
+=====================
 
-This documentation describes the structure, usage and configuration of the Bazel-based C++/Rust module template.
+This documentation describes the structure, usage and configuration of the Bazel-based C++/Rust logging module.
 
 .. contents:: Table of Contents
    :depth: 2
@@ -42,13 +42,13 @@ Requirements
 Project Layout
 --------------
 
-The module template includes the following top-level structure:
+The logging module includes the following top-level structure:
 
-- `score/`: Main C++/Rust sources
-- `tests/`: Unit and integration tests
-- `examples/`: Usage examples
-- `docs/`: Documentation using `docs-as-code`
-- `.github/workflows/`: CI/CD pipelines
+- ``score/``: Main C++/Rust sources
+- ``tests/``: Unit and integration tests
+- ``examples/``: Usage examples
+- ``docs/``: Documentation using ``docs-as-code``
+- ``.github/workflows/``: CI/CD pipelines
 
 Quick Start
 -----------
@@ -68,7 +68,7 @@ To run tests:
 Configuration
 -------------
 
-The `project_config.bzl` file defines metadata used by Bazel macros.
+The ``project_config.bzl`` file defines metadata used by Bazel macros.
 
 Example:
 
@@ -79,7 +79,7 @@ Example:
        "source_code": ["cpp", "rust"]
    }
 
-This enables conditional behavior (e.g., choosing `clang-tidy` for C++ or `clippy` for Rust).
+This enables conditional behavior (e.g., choosing ``clang-tidy`` for C++ or ``clippy`` for Rust).
 
 Decision records
 ----------------


### PR DESCRIPTION
Replace template references with logging in order to have representative header in reference_integration

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
