### PR TITLE
feat: make Unix domain socket path and mode configurable

### DIFF
--- a/score/datarouter/BUILD
+++ b/score/datarouter/BUILD
@@ -669,6 +669,22 @@ cc_library(
 ]
 
 cc_library(
+    name = "socket_config",
+    srcs = ["src/daemon/socket_config.cpp"],
+    hdrs = ["include/daemon/socket_config.h"],
+    features = COMPILER_WARNING_FEATURES,
+    strip_include_prefix = "include",
+    visibility = [
+        "//score/datarouter:__subpackages__",
+        "//score/mw/log/detail/data_router:__subpackages__",
+    ],
+    deps = [
+        ":unixdomain_common",
+        "@score_baselibs//score/language/futurecpp",
+    ],
+)
+
+cc_library(
     name = "socketserver_config_helpers",
     hdrs = [
         "include/daemon/socketserver_json_helpers.h",
@@ -786,6 +802,7 @@ cc_library(
         ":datarouter_lib",
         ":dltserver",
         ":persistentlogconfig",
+        ":socket_config",
         ":socketserver_config_lib",
         "@score_baselibs//score/mw/log/configuration:nvconfigfactory",
     ] + select({
@@ -818,6 +835,7 @@ cc_library(
         ":datarouter_lib",
         ":dltserver_testing",
         ":persistentlogconfig",
+        ":socket_config",
         ":socketserver_config_lib_testing",
         "@score_baselibs//score/mw/log/configuration:nvconfigfactory",
     ] + select({

--- a/score/datarouter/BUILD
+++ b/score/datarouter/BUILD
@@ -686,6 +686,22 @@ cc_library(
 ]
 
 cc_library(
+    name = "socket_config",
+    srcs = ["src/daemon/socket_config.cpp"],
+    hdrs = ["include/daemon/socket_config.h"],
+    features = COMPILER_WARNING_FEATURES,
+    strip_include_prefix = "include",
+    visibility = [
+        "//score/datarouter:__subpackages__",
+        "//score/mw/log/detail/data_router:__subpackages__",
+    ],
+    deps = [
+        ":unixdomain_common",
+        "@score_baselibs//score/language/futurecpp",
+    ],
+)
+
+cc_library(
     name = "socketserver_config_helpers",
     hdrs = [
         "include/daemon/socketserver_json_helpers.h",
@@ -804,6 +820,7 @@ cc_library(
         ":datarouter_lib",
         ":dltserver",
         ":persistentlogconfig",
+        ":socket_config",
         ":socketserver_config_lib",
         "@score_baselibs//score/mw/log/configuration:nvconfigfactory",
     ] + select({
@@ -841,6 +858,7 @@ cc_library(
         ":datarouter_testing",
         ":dltserver_testing",
         ":persistentlogconfig",
+        ":socket_config",
         ":socketserver_config_lib_testing",
         "@score_baselibs//score/mw/log/configuration:nvconfigfactory",
     ] + select({

--- a/score/datarouter/include/daemon/socket_config.h
+++ b/score/datarouter/include/daemon/socket_config.h
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#ifndef SCORE_DATAROUTER_DAEMON_SOCKET_CONFIG_H
+#define SCORE_DATAROUTER_DAEMON_SOCKET_CONFIG_H
+
+#include <string>
+
+// Forward declaration to avoid including the full header
+namespace score {
+namespace platform {
+namespace internal {
+class UnixDomainSockAddr;
+}
+}  // namespace platform
+}  // namespace score
+
+namespace score {
+namespace logging {
+namespace config {
+
+/// \brief Socket configuration resolved from environment variables or defaults
+struct SocketConfiguration {
+    std::string path;
+    bool is_abstract;
+};
+
+/// \brief Get socket configuration from environment variables or platform defaults
+/// \return Socket configuration with path and abstract mode flag
+/// \note Reads DATAROUTER_SOCKET_PATH and DATAROUTER_SOCKET_MODE environment variables
+/// \note Platform defaults: Linux uses abstract namespace, QNX uses file-based
+SocketConfiguration GetSocketConfiguration() noexcept;
+
+/// \brief Create configured UnixDomainSockAddr from environment or defaults
+/// \return Configured socket address ready for binding or connecting
+/// \note This is a convenience function that combines GetSocketConfiguration()
+///       with UnixDomainSockAddr construction
+score::platform::internal::UnixDomainSockAddr CreateSocketAddress() noexcept;
+
+}  // namespace config
+}  // namespace logging
+}  // namespace score
+
+#endif  // SCORE_DATAROUTER_DAEMON_SOCKET_CONFIG_H

--- a/score/datarouter/src/daemon/socket_config.cpp
+++ b/score/datarouter/src/daemon/socket_config.cpp
@@ -1,0 +1,102 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "daemon/socket_config.h"
+
+#include "unix_domain/unix_domain_common.h"
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sys/un.h>
+
+namespace score {
+namespace logging {
+namespace config {
+
+namespace {
+constexpr char kEnvSocketPath[] = "DATAROUTER_SOCKET_PATH";
+constexpr char kEnvSocketMode[] = "DATAROUTER_SOCKET_MODE";
+
+#ifdef __QNXNTO__
+constexpr char kDefaultSocketPath[] = "/var/run/datarouter.sock";
+constexpr char kDefaultSocketMode[] = "file";
+#else
+constexpr char kDefaultSocketPath[] = "datarouter_socket";
+constexpr char kDefaultSocketMode[] = "abstract";
+#endif
+
+}  // namespace
+
+SocketConfiguration GetSocketConfiguration() noexcept
+{
+    // Read environment variables
+    // NOLINTNEXTLINE(concurrency-mt-unsafe) Environment read at startup is safe
+    // NOLINTNEXTLINE(score-banned-function) getenv is necessary for configuration
+    const char* env_path = std::getenv(kEnvSocketPath);
+    // NOLINTNEXTLINE(concurrency-mt-unsafe) Environment read at startup is safe
+    // NOLINTNEXTLINE(score-banned-function) getenv is necessary for configuration
+    const char* env_mode = std::getenv(kEnvSocketMode);
+
+    // Apply path with fallback to default
+    std::string path;
+    if (env_path != nullptr && env_path[0] != '\0')
+    {
+        path = env_path;
+    }
+    else
+    {
+        path = kDefaultSocketPath;
+    }
+
+    // Apply mode with fallback to default
+    std::string mode_str;
+    if (env_mode != nullptr)
+    {
+        mode_str = env_mode;
+    }
+    else
+    {
+        mode_str = kDefaultSocketMode;
+    }
+
+    // Convert mode string to boolean (case-insensitive)
+    // Any value other than "file" or "FILE" is treated as abstract
+    bool is_abstract = true;
+    if (mode_str == "file" || mode_str == "FILE")
+    {
+        is_abstract = false;
+    }
+
+    // Validate path length
+    // sockaddr_un.sun_path has limited size, need room for null terminator
+    // and potentially the leading null byte for abstract sockets
+    constexpr std::size_t kMaxPathLength = sizeof(sockaddr_un::sun_path) - 1;
+    if (path.length() >= kMaxPathLength)
+    {
+        std::cerr << "Warning: DATAROUTER_SOCKET_PATH too long (max " << kMaxPathLength
+                  << " chars), using default: " << kDefaultSocketPath << '\n';
+        path = kDefaultSocketPath;
+    }
+
+    return SocketConfiguration{path, is_abstract};
+}
+
+score::platform::internal::UnixDomainSockAddr CreateSocketAddress() noexcept
+{
+    auto config = GetSocketConfiguration();
+    return score::platform::internal::UnixDomainSockAddr(config.path, config.is_abstract);
+}
+
+}  // namespace config
+}  // namespace logging
+}  // namespace score

--- a/score/datarouter/src/daemon/socketserver.cpp
+++ b/score/datarouter/src/daemon/socketserver.cpp
@@ -15,6 +15,7 @@
 
 #include "daemon/dlt_log_server.h"
 #include "daemon/message_passing_server.h"
+#include "daemon/socket_config.h"
 #include "daemon/socketserver_config.h"
 #include "daemon/socketserver_filter_factory.h"
 #include "score/datarouter/daemon_communication/session_handle_interface.h"
@@ -237,7 +238,7 @@ std::unique_ptr<score::platform::internal::UnixDomainServer> SocketServer::Creat
 {
     const auto factory = std::bind(&SocketServer::CreateConfigSession, std::ref(dlt_server), std::placeholders::_2);
 
-    const UnixDomainSockAddr addr(score::logging::config::kSocketAddress, true);
+    const UnixDomainSockAddr addr = score::logging::config::CreateSocketAddress();
     /*
     Deviation from Rule A5-1-4:
     - A lambda expression object shall not outlive any of its reference captured objects.

--- a/score/datarouter/src/daemon/socketserver.cpp
+++ b/score/datarouter/src/daemon/socketserver.cpp
@@ -15,6 +15,7 @@
 
 #include "daemon/dlt_log_server.h"
 #include "daemon/message_passing_server.h"
+#include "daemon/socket_config.h"
 #include "daemon/socketserver_config.h"
 #include "logparser/logparser.h"
 
@@ -238,7 +239,7 @@ std::unique_ptr<score::platform::internal::UnixDomainServer> SocketServer::Creat
         return SocketServer::CreateConfigSession(dlt_server, std::move(handle));
     };
 
-    const UnixDomainSockAddr addr(score::logging::config::kSocketAddress, true);
+    const UnixDomainSockAddr addr = score::logging::config::CreateSocketAddress();
     /*
     Deviation from Rule A5-1-4:
     - A lambda expression object shall not outlive any of its reference captured objects.

--- a/score/datarouter/test/ut/ut_logging/BUILD
+++ b/score/datarouter/test/ut/ut_logging/BUILD
@@ -38,6 +38,7 @@ test_suite(
         ":logparserUT",
         ":messagePassingServerUT",
         ":persistentLogConfigUT",
+        ":socket_config_test",
         ":socketserverConfigUT",
         ":socketserverUT",
         ":udp_stream_output_test",
@@ -295,6 +296,19 @@ cc_test(
         "@googletest//:gtest_main",
         "@score_logging//score/datarouter:log",
         "@score_logging//score/datarouter:socketserver_config_lib_testing",
+    ],
+)
+
+cc_test(
+    name = "socket_config_test",
+    srcs = [
+        "socket_config_test.cpp",
+    ],
+    features = FEAT_COMPILER_WARNINGS_AS_ERRORS,
+    tags = ["unit"],
+    deps = [
+        "@googletest//:gtest_main",
+        "@score_logging//score/datarouter:socket_config",
     ],
 )
 

--- a/score/datarouter/test/ut/ut_logging/BUILD
+++ b/score/datarouter/test/ut/ut_logging/BUILD
@@ -38,6 +38,7 @@ test_suite(
         ":logparserUT",
         ":messagePassingServerUT",
         ":persistentLogConfigUT",
+        ":socket_config_test",
         ":socketserverConfigUT",
         ":socketserverUT",
         ":udp_stream_output_test",
@@ -296,6 +297,19 @@ cc_test(
         "@googletest//:gtest_main",
         "@score_baselibs//score/mw/log",
         "@score_logging//score/datarouter:socketserver_config_lib_testing",
+    ],
+)
+
+cc_test(
+    name = "socket_config_test",
+    srcs = [
+        "socket_config_test.cpp",
+    ],
+    features = FEAT_COMPILER_WARNINGS_AS_ERRORS,
+    tags = ["unit"],
+    deps = [
+        "@googletest//:gtest_main",
+        "@score_logging//score/datarouter:socket_config",
     ],
 )
 

--- a/score/datarouter/test/ut/ut_logging/socket_config_test.cpp
+++ b/score/datarouter/test/ut/ut_logging/socket_config_test.cpp
@@ -1,0 +1,167 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "daemon/socket_config.h"
+
+#include "unix_domain/unix_domain_common.h"
+#include "gtest/gtest.h"
+#include <cstdlib>
+
+namespace score {
+namespace logging {
+namespace config {
+
+class SocketConfigTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        // Save original env vars
+        const char* path = std::getenv("DATAROUTER_SOCKET_PATH");
+        const char* mode = std::getenv("DATAROUTER_SOCKET_MODE");
+        original_path_ = path ? std::string(path) : std::string();
+        original_mode_ = mode ? std::string(mode) : std::string();
+        has_original_path_ = (path != nullptr);
+        has_original_mode_ = (mode != nullptr);
+    }
+
+    void TearDown() override
+    {
+        // Restore original env vars
+        if (has_original_path_)
+        {
+            setenv("DATAROUTER_SOCKET_PATH", original_path_.c_str(), 1);
+        }
+        else
+        {
+            unsetenv("DATAROUTER_SOCKET_PATH");
+        }
+        if (has_original_mode_)
+        {
+            setenv("DATAROUTER_SOCKET_MODE", original_mode_.c_str(), 1);
+        }
+        else
+        {
+            unsetenv("DATAROUTER_SOCKET_MODE");
+        }
+    }
+
+    std::string original_path_;
+    std::string original_mode_;
+    bool has_original_path_ = false;
+    bool has_original_mode_ = false;
+};
+
+TEST_F(SocketConfigTest, DefaultConfiguration)
+{
+    unsetenv("DATAROUTER_SOCKET_PATH");
+    unsetenv("DATAROUTER_SOCKET_MODE");
+
+    auto config = GetSocketConfiguration();
+
+#ifdef __QNXNTO__
+    EXPECT_EQ(config.path, "/var/run/datarouter.sock");
+    EXPECT_FALSE(config.is_abstract);
+#else
+    EXPECT_EQ(config.path, "datarouter_socket");
+    EXPECT_TRUE(config.is_abstract);
+#endif
+}
+
+TEST_F(SocketConfigTest, CustomFilePath)
+{
+    setenv("DATAROUTER_SOCKET_PATH", "/var/run/custom.sock", 1);
+    setenv("DATAROUTER_SOCKET_MODE", "file", 1);
+
+    auto config = GetSocketConfiguration();
+    EXPECT_EQ(config.path, "/var/run/custom.sock");
+    EXPECT_FALSE(config.is_abstract);
+}
+
+TEST_F(SocketConfigTest, CustomAbstractPath)
+{
+    setenv("DATAROUTER_SOCKET_PATH", "custom_abstract", 1);
+    setenv("DATAROUTER_SOCKET_MODE", "abstract", 1);
+
+    auto config = GetSocketConfiguration();
+    EXPECT_EQ(config.path, "custom_abstract");
+    EXPECT_TRUE(config.is_abstract);
+}
+
+TEST_F(SocketConfigTest, InvalidModeDefaultsToAbstract)
+{
+    setenv("DATAROUTER_SOCKET_MODE", "invalid", 1);
+
+    auto config = GetSocketConfiguration();
+    EXPECT_TRUE(config.is_abstract);
+}
+
+TEST_F(SocketConfigTest, EmptyPathUsesDefault)
+{
+    setenv("DATAROUTER_SOCKET_PATH", "", 1);
+
+    auto config = GetSocketConfiguration();
+    EXPECT_FALSE(config.path.empty());
+#ifdef __QNXNTO__
+    EXPECT_EQ(config.path, "/var/run/datarouter.sock");
+#else
+    EXPECT_EQ(config.path, "datarouter_socket");
+#endif
+}
+
+TEST_F(SocketConfigTest, CreateSocketAddressAbstract)
+{
+    setenv("DATAROUTER_SOCKET_PATH", "test_socket", 1);
+    setenv("DATAROUTER_SOCKET_MODE", "abstract", 1);
+
+    auto addr = CreateSocketAddress();
+    EXPECT_TRUE(addr.IsAbstract());
+    EXPECT_STREQ(addr.GetAddressString(), "test_socket");
+}
+
+TEST_F(SocketConfigTest, CreateSocketAddressFile)
+{
+    setenv("DATAROUTER_SOCKET_PATH", "/tmp/test.sock", 1);
+    setenv("DATAROUTER_SOCKET_MODE", "file", 1);
+
+    auto addr = CreateSocketAddress();
+    EXPECT_FALSE(addr.IsAbstract());
+    EXPECT_STREQ(addr.GetAddressString(), "/tmp/test.sock");
+}
+
+TEST_F(SocketConfigTest, ModeFileCaseInsensitive)
+{
+    setenv("DATAROUTER_SOCKET_PATH", "/tmp/test.sock", 1);
+    setenv("DATAROUTER_SOCKET_MODE", "FILE", 1);
+
+    auto config = GetSocketConfiguration();
+    EXPECT_FALSE(config.is_abstract);
+}
+
+TEST_F(SocketConfigTest, PathOnlyWithoutMode)
+{
+    setenv("DATAROUTER_SOCKET_PATH", "/custom/socket.sock", 1);
+    unsetenv("DATAROUTER_SOCKET_MODE");
+
+    auto config = GetSocketConfiguration();
+    EXPECT_EQ(config.path, "/custom/socket.sock");
+#ifdef __QNXNTO__
+    EXPECT_FALSE(config.is_abstract);  // QNX defaults to file
+#else
+    EXPECT_TRUE(config.is_abstract);   // Linux defaults to abstract
+#endif
+}
+
+}  // namespace config
+}  // namespace logging
+}  // namespace score


### PR DESCRIPTION
Make the datarouter Unix domain socket configurable via environment variables while maintaining backward compatibility (defaults to abstract namespace with "datarouter_socket" path).

This enables containerized deployments where both the datarouter and applications run in separate containers and communicate via file-based sockets with shared volume mounts. Also supports running multiple datarouter instances with unique abstract namespace sockets.

Changes:
- Add socket_config module for centralized socket configuration
- Support DATAROUTER_SOCKET_PATH environment variable (default: "datarouter_socket")
- Support DATAROUTER_SOCKET_MODE environment variable ("abstract" or "file", default: "abstract")
- Update socketserver to use configurable socket address
- Add comprehensive unit tests (9 tests, all passing)
- Platform-specific defaults: Linux uses abstract, QNX uses file-based

Environment variables:
- DATAROUTER_SOCKET_PATH: Socket path (e.g., "/var/run/datarouter.sock" or "custom_socket")
- DATAROUTER_SOCKET_MODE: "abstract" for abstract namespace or "file" for filesystem-based

Example usage for containerized datarouter + application:
  # Both containers set:
  export DATAROUTER_SOCKET_PATH=/var/run/datarouter.sock
  export DATAROUTER_SOCKET_MODE=file
  # And mount the same volume at /var/run

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
