### PR TITLE
Fixes log target for datarouter to use the one with all backends

### DIFF
--- a/score/datarouter/BUILD
+++ b/score/datarouter/BUILD
@@ -319,7 +319,7 @@ alias(
 cc_library(
     name = "log",
     visibility = ["//visibility:public"],
-    deps = ["@score_baselibs//score/mw/log:console"],
+    deps = ["//score/mw/log"],
 )
 
 ## ===========================================================================


### PR DESCRIPTION
Fixes log target for datarouter to use the one with all backends.

The issue was identified when integrating datarouter in the reference_integration platform:
https://github.com/eclipse-score/reference_integration/actions/runs/25167644933/job/73777975363?pr=213
>           raise IOError(DLT_EMPTY_FILE_ERROR)
> E           OSError: DLT TRACE FILE IS EMPTY

../score_itf++_repo_rules+python_dlt/dlt/dlt.py:888: OSError

Apparently the remote backend was missing. The log target was replaced during the export which needs fixing.


<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
