### PR TITLE
Removes and replaces deprecated bazel targets

### DIFF
--- a/score/datarouter/BUILD
+++ b/score/datarouter/BUILD
@@ -206,9 +206,9 @@ cc_library(
     deps = [
         ":datarouter_types",
         ":dltprotocol",
-        ":log",
         ":logparser_interface",
         "//score/mw/log/detail/data_router/shared_memory:reader",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/mw/log/configuration:nvconfig",
         "@score_baselibs//score/static_reflection_with_serialization/serialization",
     ],
@@ -308,20 +308,6 @@ cc_library(
     ],
 )
 
-# FIXME: Ticket-252685
-alias(
-    name = "libtracing",
-    actual = ":log",
-    visibility = ["//visibility:public"],
-)
-
-# FIXME: Ticket-252685
-cc_library(
-    name = "log",
-    visibility = ["//visibility:public"],
-    deps = ["//score/mw/log"],
-)
-
 ## ===========================================================================
 ##  Datarouter
 ## ---------------------------------------------------------------------------
@@ -396,7 +382,7 @@ cc_library(
     strip_include_prefix = "src/applications",
     visibility = ["//score/datarouter/test:__subpackages__"],
     deps = [
-        ":log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -413,7 +399,7 @@ cc_library(
         "@score_logging//score/datarouter:__subpackages__",
     ],
     deps = [
-        ":log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -429,7 +415,6 @@ cc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":datarouter_types",
-        ":log",
         ":logparser",
         ":logparser_factory_interface",
         ":message_passing_server",
@@ -437,6 +422,7 @@ cc_library(
         "//score/mw/log/detail/data_router/shared_memory:reader",
         "@score_baselibs//score/concurrency:synchronized",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -453,12 +439,12 @@ cc_library(
         "//score/datarouter/test/benchmark:__subpackages__",
     ],
     deps = [
-        ":log",
         ":logparser",
         ":logparser_factory_interface",
         ":message_passing_server",
         ":unixdomain_mock",
         "@score_baselibs//score/concurrency:synchronized",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -476,12 +462,12 @@ cc_library(
     ],
     deps = [
         ":datarouter_types",
-        ":log",
         ":logparser_factory_interface",
         ":logparser_testing",
         ":message_passing_server",
         ":unixdomain_mock",
         "@score_baselibs//score/concurrency:synchronized",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -633,8 +619,6 @@ cc_library(
         ":dlt_log_channel_lib",
         ":dltserver_common",
         ":libdrconfighdrs",
-        ":libtracing",
-        ":log",
         ":log_entry_deserialization",
         ":log_sender",
         ":logchannel_utility",
@@ -643,6 +627,7 @@ cc_library(
         "//score/datarouter/network:vlan",
         "//score/datarouter/src/persistent_logging/persistent_logging_stub:sysedr_stub",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/mw/log/configuration:nvconfig",
         "@score_baselibs//score/os:socket",
         "@score_baselibs//score/os:stat",
@@ -670,7 +655,7 @@ cc_library(
         ],
         deps = [
             ":dltserver_common",
-            ":log",
+            "@score_baselibs//score/mw/log",
             "@score_baselibs//score/mw/log/configuration:nvconfig",
             "@score_baselibs//score/os:socket",
             "@score_baselibs//score/os:stat",
@@ -727,11 +712,11 @@ cc_library(
     ],
     deps = [
         ":dltprotocol",
-        ":log",
         ":logchannel_utility",
         ":socketserver_config_helpers",
         "//score/datarouter/src/persistency:interface",
         "@rapidjson",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -870,7 +855,7 @@ cc_library(
         visibility = ["//score/datarouter/test:__subpackages__"],
         deps = [
             ":datarouter_options",
-            ":log",
+            "@score_baselibs//score/mw/log",
         ] + deps,
     )
     for (name, deps, test_only) in [
@@ -905,8 +890,12 @@ cc_binary(
         "@score_baselibs//score/os:errno_logging",
         "@score_baselibs//score/os:pthread",
         "@score_baselibs//score/os/utils:path",
-        # "//third_party/jemalloc", # Ticket-231781
-    ],
+        "@score_logging//score/mw/log/backend:file",
+        "@score_logging//score/mw/log/backend:remote",
+    ] + select({
+        "@platforms//os:qnx": ["//score/mw/log/backend:slog"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -1105,7 +1094,7 @@ cc_library(
         "@score_baselibs//score/os:stdio",
         "@score_baselibs//score/os/utils:path",
         "@score_baselibs//score/os/utils:thread",
-        ":log",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/mw/log/configuration:nvconfig",
         "//score/datarouter/dlt_filetransfer_trigger_lib:filetransfer_message_types",
         "//score/datarouter/src/persistent_logging/persistent_logging_stub:sysedr_stub",

--- a/score/datarouter/dlt_filetransfer_trigger_lib/BUILD
+++ b/score/datarouter/dlt_filetransfer_trigger_lib/BUILD
@@ -48,7 +48,7 @@ cc_library(
     deps = [
         "filetransfer_message_types",
         "//score/mw/log/legacy_non_verbose_api",
-        "@score_logging//score/datarouter:log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/datarouter/src/dlt/nonverbose_dlt_impl/BUILD
+++ b/score/datarouter/src/dlt/nonverbose_dlt_impl/BUILD
@@ -42,8 +42,8 @@ clang_tidy_extra_checks(
             "@score_logging//score/datarouter:__subpackages__",
         ],
         deps = [
+            "@score_baselibs//score/mw/log",
             "@score_baselibs//score/mw/log/configuration:nvconfig",
-            "@score_logging//score/datarouter:log",
             "@score_logging//score/datarouter:logparser",
         ] + dep,
     )

--- a/score/datarouter/src/dlt/nonverbose_dlt_stub/BUILD
+++ b/score/datarouter/src/dlt/nonverbose_dlt_stub/BUILD
@@ -39,8 +39,8 @@ clang_tidy_extra_checks(
             "@score_logging//score/datarouter:__subpackages__",
         ],
         deps = [
+            "@score_baselibs//score/mw/log",
             "@score_baselibs//score/mw/log/configuration:nvconfig",
-            "@score_logging//score/datarouter:log",
             "@score_logging//score/datarouter:logparser",
         ] + dep,
     )

--- a/score/datarouter/src/file_transfer/file_transfer_stub/BUILD
+++ b/score/datarouter/src/file_transfer/file_transfer_stub/BUILD
@@ -42,9 +42,9 @@ cc_library(
     ],
     deps = [
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
         "@score_logging//score/datarouter:dltprotocol",
         "@score_logging//score/datarouter:dltserver_common",
-        "@score_logging//score/datarouter:log",
         "@score_logging//score/datarouter:logparser",
     ],
 )

--- a/score/datarouter/src/persistent_logging/persistent_logging_stub/BUILD
+++ b/score/datarouter/src/persistent_logging/persistent_logging_stub/BUILD
@@ -27,6 +27,6 @@ cc_library(
     deps = [
         "//score/datarouter/src/persistent_logging:sysedr_factory",
         "//score/datarouter/src/persistent_logging:sysedr_handler_interface",
-        "@score_logging//score/datarouter:log",
+        "@score_baselibs//score/mw/log",
     ],
 )

--- a/score/datarouter/test/ut/ut_logging/BUILD
+++ b/score/datarouter/test/ut/ut_logging/BUILD
@@ -198,8 +198,8 @@ cc_test(
     tags = ["unit"],
     deps = [
         "@googletest//:gtest_main",
+        "@score_baselibs//score/mw/log",
         "@score_logging//score/datarouter:dltserver_testing",
-        "@score_logging//score/datarouter:log",
     ],
 )
 
@@ -227,7 +227,7 @@ cc_test(
         # buildifier off
         "@score_logging//score/datarouter:dltserver_testing",
         # buildifier on
-        "@score_logging//score/datarouter:log",
+        "@score_baselibs//score/mw/log",
         "@score_logging//score/datarouter:datarouter_feature_config_testing",
         "//score/datarouter/dlt_filetransfer_trigger_lib",
         "@googletest//:gtest_main",
@@ -243,8 +243,8 @@ cc_test(
     tags = ["unit"],
     deps = [
         "@googletest//:gtest_main",
+        "@score_baselibs//score/mw/log",
         "@score_logging//score/datarouter:datarouter_options",
-        "@score_logging//score/datarouter:log",
     ],
 )
 
@@ -257,8 +257,8 @@ cc_test(
     tags = ["unit"],
     deps = [
         "@googletest//:gtest_main",
+        "@score_baselibs//score/mw/log",
         "@score_logging//score/datarouter:datarouter_app_testing",
-        "@score_logging//score/datarouter:log",
     ],
 )
 
@@ -274,7 +274,7 @@ cc_test(
     tags = ["unit"],
     deps = [
         "@googletest//:gtest_main",
-        "@score_logging//score/datarouter:log",
+        "@score_baselibs//score/mw/log",
         "@score_logging//score/datarouter:persistentlogconfig",
     ],
 )
@@ -293,7 +293,7 @@ cc_test(
     deps = [
         "//score/datarouter/src/persistency/stub_persistent_dictionary:stub",
         "@googletest//:gtest_main",
-        "@score_logging//score/datarouter:log",
+        "@score_baselibs//score/mw/log",
         "@score_logging//score/datarouter:socketserver_config_lib_testing",
     ],
 )


### PR DESCRIPTION
- The "log" target in "score_logging" is deprecated and the one from baselibs shall be used henceforth

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
