### PR TITLE
Add ARM64 Linux layout support to score_log_bridge

### DIFF
--- a/score/mw/log/rust/score_log_bridge/BUILD
+++ b/score/mw/log/rust/score_log_bridge/BUILD
@@ -23,6 +23,14 @@ config_setting(
 )
 
 config_setting(
+    name = "arm64-linux",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
     name = "arm64-qnx",
     constraint_values = [
         "@platforms//cpu:arm64",
@@ -44,6 +52,7 @@ cc_library(
     # C++/Rust interface objects must share layout.
     defines = select({
         ":x86_64-linux": ["x86_64_linux"],
+        ":arm64-linux": ["arm64_linux"],
         ":arm64-qnx": ["arm64_qnx"],
         ":x86_64-qnx": ["x86_64_qnx"],
         "//conditions:default": [],
@@ -65,6 +74,7 @@ rust_library(
     # C++/Rust interface objects must share layout.
     crate_features = select({
         ":x86_64-linux": ["x86_64_linux"],
+        ":arm64-linux": ["arm64_linux"],
         ":arm64-qnx": ["arm64_qnx"],
         ":x86_64-qnx": ["x86_64_qnx"],
         "//conditions:default": [],
@@ -94,6 +104,7 @@ rust_test(
     crate = "score_log_bridge",
     crate_features = select({
         ":x86_64-linux": ["x86_64_linux"],
+        ":arm64-linux": ["arm64_linux"],
         ":arm64-qnx": ["arm64_qnx"],
         ":x86_64-qnx": ["x86_64_qnx"],
         "//conditions:default": [],


### PR DESCRIPTION
## Summary

Adds `arm64-linux` platform support to `score/mw/log/rust/score_log_bridge/BUILD`
so that the C++/Rust log bridge builds correctly on `aarch64-linux` targets
(e.g. `eb-aarch64` / ebclfsa SDK).

## Why

The `adapter` cc_library and `score_log_bridge` rust_library both use a `select()`
to emit the correct layout-compatibility define (`x86_64_linux`, `arm64_qnx`, etc.).
Without an `arm64-linux` entry, builds targeting `aarch64-linux` fall through to
`//conditions:default: []`, meaning no define is set. This causes a compilation
failure in the C++/Rust FFI interface because the struct layout is undefined.

## Change

- Adds a new `config_setting(name = "arm64-linux", ...)` for `arm64 + linux`.
- Adds `":arm64-linux": ["arm64_linux"]` to the `defines` select in `cc_library`
  and the `crate_features` select in both `rust_library` and `rust_test`.