### PR TITLE
test: point the Verifies trace at the symbol that exists

### DIFF
--- a/score/mw/log/detail/wait_free_producer_queue/alternating_control_block_test.cpp
+++ b/score/mw/log/detail/wait_free_producer_queue/alternating_control_block_test.cpp
@@ -92,9 +92,7 @@ TEST(AlternatingControlBlockTest, GetOppositeLinearControlBlockShallReturnkBlock
 {
     RecordProperty("DerivationTechnique", "Analysis of boundary values");
     RecordProperty("TestingTechnique", "Interface tests");
-    RecordProperty("Verifies",
-                   "score::mw::log::detail::wait_free_producer_queue::alternating_control_block_test::"
-                   "GetOppositeLinearControlBlock");
+    RecordProperty("Verifies", "::score::mw::log::detail::GetOppositeLinearControlBlock()");
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies the ability of returning the default value in case of passing unknown value to "


### PR DESCRIPTION
The `RecordProperty("Verifies", ...)` record in `alternating_control_block_test.cpp:95` names a symbol that does not exist:

```
score::mw::log::detail::wait_free_producer_queue::alternating_control_block_test::GetOppositeLinearControlBlock
```

Two components of that path are not namespaces:

* **`wait_free_producer_queue`** is the directory. `grep -rn "namespace *wait_free_producer_queue"` over the repository returns nothing.
* **`alternating_control_block_test`** is this test file's own basename. Same result — it is never declared as a namespace.

`GetOppositeLinearControlBlock` is declared in `alternating_control_block.h:75`, inside `score` → `mw` → `log` → `detail` (opened at lines 19–25, closed at 78–81). So the qualified name is:

```
score::mw::log::detail::GetOppositeLinearControlBlock
```

## Why it matters here rather than being cosmetic

`Verifies` is the trace from a test to the unit under test, and this test is marked `ASIL B`. The record is traceability evidence: it builds, the test passes, and the link points at nothing. Nothing catches it either — clang-tidy sees a string literal, and the string is only ever read by whatever consumes the test report.

## Form

The other twenty `Verifies` records in the repository, all in `score/datarouter/test/ut/ut_logging/test_socketserver.cpp`, are written with a leading `::` and a trailing `()`:

```cpp
RecordProperty("Verifies", "::score::platform::datarouter::SocketServer::CreateDltServer()");
```

so this one is written the same way rather than only having the two bogus components removed.

```diff
-    RecordProperty("Verifies",
-                   "score::mw::log::detail::wait_free_producer_queue::alternating_control_block_test::"
-                   "GetOppositeLinearControlBlock");
+    RecordProperty("Verifies", "::score::mw::log::detail::GetOppositeLinearControlBlock()");
```

## How this was found, and what I did not touch

I extracted every `RecordProperty("Verifies", ...)` value in the repository — 21 sites, which matches `grep -c` exactly, so the extraction is complete — and resolved each named symbol against the declarations in the tree. This is the only one that does not resolve.

Something I noticed but deliberately left alone: `Verifies` coverage in `score/mw/log/detail/wait_free_producer_queue/` is sparse — 1 record across 22 tests in 5 files, and this was that one record.

| file | Verifies | tests |
|---|---|---|
| `alternating_control_block_test.cpp` | 1 | 5 |
| `linear_control_block_test.cpp` | 0 | 2 |
| `linear_reader_test.cpp` | 0 | 1 |
| `wait_free_alternating_writer_test.cpp` | 0 | 5 |
| `wait_free_linear_writer_test.cpp` | 0 | 9 |

Adding the missing ones would mean deciding what each test actually verifies, which is a call for whoever owns that component, so this PR only corrects the record that is wrong. Happy to follow up if that is wanted.

## Checks

* Both bogus path components confirmed absent as namespaces across all `.h`, `.hpp` and `.cpp` in the repository.
* The corrected path read from the enclosing `namespace` blocks in `alternating_control_block.h`, not inferred from the directory layout.
* One line of test metadata; no production code, no test logic, no build changes.
* ECA signed; the commit carries `Signed-off-by`.

## AI disclosure

AI-assisted (Claude Code). The extraction and this description were produced with the tool, and I checked the result before opening: I confirmed the extraction found every `RecordProperty("Verifies", ...)` in the tree by comparing against `grep -c`, read the namespace nesting in the header rather than assuming it from the path, searched for both suspect components as namespace declarations and found neither, and compared against the twenty existing records to match their form.

Worth stating, because it nearly cost me this finding: my first pass validated each claimed symbol against the set of identifiers appearing anywhere in the repository — which included the claim string itself, so `alternating_control_block_test` "existed" and the record looked fine. A claim cannot be checked against a corpus that contains the claim. I have reviewed and understood the change and take responsibility for it.
