### PR TITLE
Adds py_unittest_qnx_test removed by baselibs

### DIFF
--- a/score/datarouter/test/BUILD
+++ b/score/datarouter/test/BUILD
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@score_baselibs//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
+load("@score_logging//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
 
 ## ---------------------------------------------------------------------------
 ## Unit tests

--- a/score/datarouter/test/ut/BUILD
+++ b/score/datarouter/test/ut/BUILD
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@score_baselibs//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
+load("@score_logging//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
 
 ## ---------------------------------------------------------------------------
 ## Unit tests

--- a/score/datarouter/test/ut/ut_logging/BUILD
+++ b/score/datarouter/test/ut/ut_logging/BUILD
@@ -12,7 +12,7 @@
 # *******************************************************************************
 
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@score_baselibs//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
+load("@score_logging//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
 
 FEAT_COMPILER_WARNINGS_AS_ERRORS = [
     "treat_warnings_as_errors",

--- a/score/mw/log/detail/slog/BUILD
+++ b/score/mw/log/detail/slog/BUILD
@@ -12,7 +12,7 @@
 # *******************************************************************************
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("@score_baselibs//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
+load("@score_logging//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
 load("//:score/mw/common_features.bzl", "COMPILER_WARNING_FEATURES")
 
 cc_library(

--- a/third_party/itf/BUILD
+++ b/third_party/itf/BUILD
@@ -1,0 +1,14 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+exports_files(["py_unittest_qnx_test.bzl"])

--- a/third_party/itf/py_unittest_qnx_test.bzl
+++ b/third_party/itf/py_unittest_qnx_test.bzl
@@ -1,0 +1,24 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+def py_unittest_qnx_test(
+        name,
+        test_cases = [],
+        test_suites = [],
+        data_files = [],  # unused: cc_test_qnx has no data param, data must live on the wrapped cc_test
+        excluded_tests_filter = None,
+        visibility = None):
+    # This is intentionally left blank.
+    # The cc_test_qnx from @score_qnx_unit_tests can be used here
+    # See: eclipse-score/logging/issues/267
+    pass


### PR DESCRIPTION
- The wrapper is still needed to support the exports from internal repo while still having
the test targets in place.
- baselibs refs: https://github.com/eclipse-score/baselibs/blob/v0.2.10/third_party/itf/py_unittest_qnx_test.bzl
- Follow-up task: https://github.com/eclipse-score/logging/issues/267